### PR TITLE
calicoctl replaces calico

### DIFF
--- a/debian/calico.dirs
+++ b/debian/calico.dirs
@@ -1,4 +1,0 @@
-etc/cni/net.d
-opt/cni/bin
-var/log/calico
-var/lib/calico

--- a/debian/calico.install
+++ b/debian/calico.install
@@ -1,1 +1,0 @@
-calicoctl usr/bin

--- a/debian/control
+++ b/debian/control
@@ -14,3 +14,4 @@ Package: calicoctl
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Calico CLI tool
+Replaces: calico

--- a/debian/control
+++ b/debian/control
@@ -5,11 +5,6 @@ Build-Depends: debhelper (>= 9),
                dh-systemd,
                zip
 
-Package: calico
-Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}
-Description: Calico CLI tool and Calico network plugin for CNI
-
 Package: calicoctl
 Architecture: any
 Depends: ${misc:Depends}, ${shlibs:Depends}

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,7 @@
 
 DISTRIBUTION = $(shell lsb_release -sc)
 VERSION = 3.12.0
-PACKAGEVERSION = $(VERSION)-2~$(DISTRIBUTION)0
+PACKAGEVERSION = $(VERSION)-3~$(DISTRIBUTION)0
 URL3 = https://github.com/projectcalico/calicoctl/releases/download/v$(VERSION)/calicoctl-linux-amd64
 
 


### PR DESCRIPTION
- we can not install calicoctl if calico is installed
- in puppet, we can not uninstall an held package